### PR TITLE
Fix for cache file name in edgecase

### DIFF
--- a/Horatio/Horatio/Classes/Services/ServiceRequestOperation.swift
+++ b/Horatio/Horatio/Classes/Services/ServiceRequestOperation.swift
@@ -57,10 +57,13 @@ open class FetchServiceResponseOperation: GroupOperation {
     // MARK: - Private
 
     fileprivate static func generatedCacheFileName(_ request: ServiceRequest) -> String {
-        guard let url = request.url, !(url.hasDirectoryPath && url.lastPathComponent.count == 1) else { return UUID().uuidString }
-
-        let lastComponent = url.lastPathComponent
-        return lastComponent
+        guard let url = request.url else { return UUID().uuidString }
+        
+        let cacheComponent = url.lastPathComponent
+        let hasValidCacheComponent = !(url.hasDirectoryPath && cacheComponent.count == 1)
+        guard hasValidCacheComponent else { return UUID().uuidString }
+        
+        return cacheComponent
     }
 }
 

--- a/Horatio/Horatio/Classes/Services/ServiceRequestOperation.swift
+++ b/Horatio/Horatio/Classes/Services/ServiceRequestOperation.swift
@@ -57,9 +57,10 @@ open class FetchServiceResponseOperation: GroupOperation {
     // MARK: - Private
 
     fileprivate static func generatedCacheFileName(_ request: ServiceRequest) -> String {
-        guard let url = request.url else { return UUID().uuidString }
+        guard let url = request.url, !(url.hasDirectoryPath && url.lastPathComponent.count == 1) else { return UUID().uuidString }
 
         let lastComponent = url.lastPathComponent
+        
         return lastComponent
     }
 }

--- a/Horatio/Horatio/Classes/Services/ServiceRequestOperation.swift
+++ b/Horatio/Horatio/Classes/Services/ServiceRequestOperation.swift
@@ -60,7 +60,6 @@ open class FetchServiceResponseOperation: GroupOperation {
         guard let url = request.url, !(url.hasDirectoryPath && url.lastPathComponent.count == 1) else { return UUID().uuidString }
 
         let lastComponent = url.lastPathComponent
-        
         return lastComponent
     }
 }


### PR DESCRIPTION
If a URL's lastPathComponent results in just "/", the cache filename should be a UUID.