### PR TITLE
Update KVO notifications style.

### DIFF
--- a/Horatio/Horatio/Classes/Operations/Operation.swift
+++ b/Horatio/Horatio/Classes/Operations/Operation.swift
@@ -20,8 +20,11 @@ open class Operation: Foundation.Operation {
     override open class func keyPathsForValuesAffectingValue(forKey key: String) -> Set<String> {
         var set = super.keyPathsForValuesAffectingValue(forKey: key)
 
-        if key == "isReady" || key == "isExecuting" || key == "isFinished" || key == "isCancelled" {
+        switch key {
+        case #keyPath(isReady), #keyPath(isExecuting), #keyPath(isFinished), #keyPath(isCancelled):
             set.insert("state")
+        default:
+            break
         }
 
         return set


### PR DESCRIPTION
- After talking to @UpBra it seems this was a change made on other projects awhile ago to fix issues with hung operations. The first thing that this added newly was observation changes to isExecuting, which we didn't have before, and the other is using a different KVO method by registering isReady, isExecuting, isFinished, and isCancelled as KVO dependent on state, which seems to fix our issue with the OperationQueue not calling start() on the Operation sometimes.

- Here is the original PR Blair opened up against the master branch on Kevin's repo. https://github.com/ktatroe/MPA-Horatio/pull/28