### PR TITLE
Block Operation updates

### DIFF
--- a/Horatio/Horatio/Classes/Operations/BlockOperation.swift
+++ b/Horatio/Horatio/Classes/Operations/BlockOperation.swift
@@ -31,6 +31,20 @@ open class BlockOperation: Operation {
         super.init()
         name = "Block Operation"
     }
+
+    /**
+     A convenience initializer that will run on an arbitrary queue
+
+     - parameter block: The block to execute. Note
+     that this block does not have a "continuation" block to execute (unlike
+     the designated initializer). The operation will automatically be ended after the 'block' has been executed.
+     */
+    public convenience init(block: @escaping ()->()) {
+        self.init(block: { continuation in
+            block()
+            continuation(nil)
+        })
+    }
     
     /**
      A convenience initializer to execute a block on the main queue.
@@ -55,8 +69,8 @@ open class BlockOperation: Operation {
             return
         }
         
-        block { _ in
-            self.finish()
+        block { error in
+            self.finishWithError(error)
         }
     }
 }

--- a/Horatio/Horatio/Classes/Services/ServiceRequestOperation.swift
+++ b/Horatio/Horatio/Classes/Services/ServiceRequestOperation.swift
@@ -50,14 +50,14 @@ public class FetchServiceResponseOperation: GroupOperation {
 
         let processOperation = ProcessServiceResponseOperation(request: request, responseProcessor: responseProcessor)
 
-        let dataPassingOperation = BlockOperation { [weak processOperation] in
+        let dataPassingOperation = BlockOperation(block: { [weak processOperation] in
             guard let processOperation = processOperation else {
                 assertionFailure("Process Operation should always exist when evaluating the data passing operation")
                 return
             }
-
+            
             processOperation.responseData = fetchOperation.responseData
-        }
+        })
 
         dataPassingOperation.addDependency(fetchOperation)
         processOperation.addDependency(dataPassingOperation)


### PR DESCRIPTION
Added convenience initializer for the BlockOperation that will allow one to avoid using the continuation and still run on a background thread.

Also updated the ServiceRequestOperation dataPassingOperation to use this initializer instead of the mainQueue one.