### PR TITLE
Removing references to Apple HealthKit in Swift Packages.

### DIFF
--- a/Horatio/Horatio/Classes/Operations/HealthCondition.swift
+++ b/Horatio/Horatio/Classes/Operations/HealthCondition.swift
@@ -8,6 +8,8 @@ This file shows an example of implementing the OperationCondition protocol.
 
 #if os(iOS)
 
+#if !DISABLE_HEALTHKIT
+
 import HealthKit
 import UIKit
 
@@ -125,4 +127,5 @@ private class HealthPermissionOperation: Operation {
 
 }
 
+#endif
 #endif

--- a/Horatio/Horatio/Classes/Operations/HealthCondition.swift
+++ b/Horatio/Horatio/Classes/Operations/HealthCondition.swift
@@ -6,9 +6,7 @@ Abstract:
 This file shows an example of implementing the OperationCondition protocol.
 */
 
-#if os(iOS)
-
-#if !DISABLE_HEALTHKIT
+#if !HORATIO_DISABLE_HEALTHKIT && os(iOS)
 
 import HealthKit
 import UIKit
@@ -127,5 +125,4 @@ private class HealthPermissionOperation: Operation {
 
 }
 
-#endif
 #endif

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
             name: "Horatio",
             path: "Horatio/Horatio",
             swiftSettings: [
-                .define("DISABLE_HEALTHKIT")
+                .define("HORATIO_DISABLE_HEALTHKIT")
             ]),
         .testTarget(
             name: "HoratioTests",

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,10 @@ let package = Package(
     targets: [
         .target(
             name: "Horatio",
-            path: "Horatio/Horatio"),
+            path: "Horatio/Horatio",
+            swiftSettings: [
+                .define("DISABLE_HEALTHKIT")
+            ]),
         .testTarget(
             name: "HoratioTests",
             dependencies: ["Horatio"],


### PR DESCRIPTION
In the NBA Project, we are getting an error when submitting to iTunes, that our app is referencing Apple HealthKit.

Adding `HORATIO_DISABLE_HEALTHKIT` flag to swift.package file, and checking flag before importing HealthKit, or declaring any class in `HealthCondition.swift` resolves this issue. 

In Testing, it appears that this flag does not impact other projects importing these files, unless they define the same flag.