### PR TITLE
Fix group operation access race

### DIFF
--- a/Horatio/Horatio/Classes/Operations/GroupOperation.swift
+++ b/Horatio/Horatio/Classes/Operations/GroupOperation.swift
@@ -22,11 +22,11 @@ import Foundation
     be executed before the rest of the operations in the initial chain of operations.
 */
 open class GroupOperation: Operation {
-    fileprivate let internalQueue = OperationQueue()
-    fileprivate let startingOperation = Foundation.BlockOperation(block: {})
-    fileprivate let finishingOperation = Foundation.BlockOperation(block: {})
+    private let internalQueue = OperationQueue()
+    private let startingOperation = Foundation.BlockOperation(block: {})
+    private let finishingOperation = Foundation.BlockOperation(block: {})
 
-    fileprivate var aggregatedErrors = [Error]()
+    private var aggregatedErrors = [Error]()
 
     public convenience init(operations: Foundation.Operation...) {
         self.init(operations: operations)


### PR DESCRIPTION
This pull request fixes an issue where the GroupOperation was accessing `aggregatedErrors` in a non thread safe manner. To fix this I added a DispatchQueue that will access `aggregatedErrors` in a thread safe manner.

Also changed some access levels from `fileprivate` to `private`.

After this PR is merged please create a new release so that it is accessible from Swift Package Manager (SPM).